### PR TITLE
[NETBEANS-54] Module Review editor.settings 

### DIFF
--- a/editor.settings/branch-info.txt
+++ b/editor.settings/branch-info.txt
@@ -1,3 +1,22 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+
+
 Branch created from: editor_settings_90403_base
 Last update from trunk (rebased to): before_hg
 Last merge to trunk (delivered from): editor_settings_90403_delivery_3

--- a/editor.settings/branch-info.txt
+++ b/editor.settings/branch-info.txt
@@ -16,7 +16,6 @@ specific language governing permissions and limitations
 under the License.
 
 
-
 Branch created from: editor_settings_90403_base
 Last update from trunk (rebased to): before_hg
 Last merge to trunk (delivered from): editor_settings_90403_delivery_3


### PR DESCRIPTION
Fixes #52

Cleanup NetBeans license header for module editor.settings/branch-info.txt. 
Added Apache License Header.