### PR TITLE
[NETBEANS-54] Module Review apisupport.harness

### DIFF
--- a/apisupport.harness/windows-launcher-src/app.rc
+++ b/apisupport.harness/windows-launcher-src/app.rc
@@ -1,38 +1,19 @@
-// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Copyright 2005, 2016 Oracle and/or its affiliates. All rights reserved.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-// Other names may be trademarks of their respective owners.
-//
-// The contents of this file are subject to the terms of either the GNU
-// General Public License Version 2 only ("GPL") or the Common
-// Development and Distribution License("CDDL") (collectively, the
-// "License"). You may not use this file except in compliance with the
-// License. You can obtain a copy of the License at
-// http://www.netbeans.org/cddl-gplv2.html
-// or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-// specific language governing permissions and limitations under the
-// License.  When distributing the software, include this License Header
-// Notice in each file and include the License file at
-// nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-// particular file as subject to the "Classpath" exception as provided
-// by Oracle in the GPL Version 2 section of the License file that
-// accompanied this code. If applicable, add the following below the
-// License Header, with the fields enclosed by brackets [] replaced by
-// your own identifying information:
-// "Portions Copyrighted [year] [name of copyright owner]"
-//
-// If you wish your version of this file to be governed by only the CDDL
-// or only the GPL Version 2, indicate your decision by adding
-// "[Contributor] elects to include this software in this distribution
-// under the [CDDL or GPL Version 2] license." If you do not indicate a
-// single choice of license, a recipient has the option to distribute
-// your version of this file under either the CDDL, the GPL Version 2 or
-// to extend the choice of license to its licensees as provided above.
-// However, if you add GPL Version 2 code and therefore, elected the GPL
-// Version 2 license, then the option applies only if the new code is
-// made subject to such option by the copyright holder.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.


### PR DESCRIPTION
Related to #14.

I didn't modify `apisupport.harness/jnlp-manifest.mf` because I think it's part of the “Problems to be solved centrally” (namely a manifest license header).